### PR TITLE
Update docker-compose.yml to use pre-built image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,10 +2,7 @@ name: Build and Publish Docker Image
 
 on:
   push:
-    branches: [ main ]
     tags: [ 'v*' ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build-and-push:
@@ -46,7 +43,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,9 @@ jobs:
         with:
           images: ghcr.io/dvelopment/slack-mcp-server-sse
           tags: |
-            type=semver,pattern={{version}}
+            type=ref,event=tag,pattern=v{{version}}
+            type=ref,event=tag,pattern=v{{major}}.{{minor}}
+            type=ref,event=tag,pattern=v{{major}}
             type=ref,event=branch
             type=ref,event=pr
             type=sha,format=short
@@ -44,7 +46,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,14 @@ name: slack-mcp-server
 
 services:
   slack-mcp-server:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    image: slack-mcp-server-sse:local
+    # The following build configuration is for building the image locally
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
+    # image: slack-mcp-server-sse:local
+    
+    # Use the pre-built Docker image from GitHub Container Registry
+    image: ghcr.io/dvelopment/slack-mcp-server-sse
     container_name: slack-mcp-server-sse
     ports:
       - "${PORT:-3000}:${PORT:-3000}"


### PR DESCRIPTION
This PR updates the docker-compose.yml file to:

1. Comment out the local build configuration
2. Add explanatory comments about local vs. pre-built image usage
3. Add configuration to use the pre-built image from GitHub Container Registry (ghcr.io)

These changes make it easier for users to get started with the server by using the pre-built image directly instead of having to build it locally.

Additionally, this PR updates the GitHub Actions workflow (.github/workflows/docker-publish.yml) to:

1. Only run on tag pushes that start with 'v' (not on pushes to main branch or pull requests)
2. Simplify the push condition since it will only run on tags